### PR TITLE
Replace itms protocol by itms-apps

### DIFF
--- a/configuration-server-boot/src/test/resources/data.sql
+++ b/configuration-server-boot/src/test/resources/data.sql
@@ -19,7 +19,7 @@ INSERT INTO CONFIGURATION.GENERAL_CONFIGURATION (NM_ID_GEN_CONFIGURATION_TYPE, N
 (4, 1, 'AndroidUrl', 'https://play.google.com/store/apps/details?id=es.gob.radarcovid', null, null),
 (4, 1, 'iOSVersion', '1.0.0', null, null),
 (4, 1, 'iOSCompilation', '1', null, null),
-(4, 1, 'iOSUrl', 'itms://itunes.apple.com/app/id1520443509', null, null),
+(4, 1, 'iOSUrl', 'itms-apps://itunes.apple.com/app/id1520443509', null, null),
 (5, 1, 'Min Duration For Exposure', '15', null, null),
 (6, 2, 'Attenuation Factor', null, '1.0', '0.5'),
 (7, 1, 'HighRiskToLowRisk', '20160', null, null),

--- a/responses/response-settings.json
+++ b/responses/response-settings.json
@@ -77,7 +77,7 @@
     "ios": {
       "version": "1.0.0",
       "compilation": 0,
-      "bundleUrl": "itms://itunes.apple.com/app/id1520443509"
+      "bundleUrl": "itms-apps://itunes.apple.com/app/id1520443509"
     }
   },
   "timeBetweenStates": {

--- a/sql/02-CONFIGURATION-DML.sql
+++ b/sql/02-CONFIGURATION-DML.sql
@@ -16,7 +16,7 @@ INSERT INTO CONFIGURATION.GENERAL_CONFIGURATION (NM_ID_GEN_CONFIGURATION_TYPE, N
 (4, 1, 'AndroidUrl', 'https://play.google.com/store/apps/details?id=es.gob.radarcovid', null, null),
 (4, 1, 'iOSVersion', '1.0.0', null, null),
 (4, 1, 'iOSCompilation', '1', null, null),
-(4, 1, 'iOSUrl', 'itms://itunes.apple.com/app/id1520443509', null, null),
+(4, 1, 'iOSUrl', 'itms-apps://itunes.apple.com/app/id1520443509', null, null),
 (5, 1, 'Min Duration For Exposure', '15', null, null),
 (6, 2, 'Attenuation Factor', null, '1.0', '0.5'),
 (7, 1, 'HighRiskToLowRisk', '20160', null, null),


### PR DESCRIPTION
The **itms** protocol leads to the iTunes Store, while **itms-apps** leads to the AppStore, which is the right thing to do.
This fixes the iOS update issue, which now redirects to the iTunes Store, not designed for downloading apps.